### PR TITLE
Added text parser to urlencoded type.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -92,6 +92,7 @@ function Server(contentDirectory, lambdaApi, logger) {
 	let api = express.Router();
 	this.App.use('/api/', api);
 
+	api.use(bodyParser.text({ type: 'application/x-www-form-urlencoded' }));
 	api.use(bodyParser.json({ type: '*/*' }));
 	/* eslint-disable-next-line no-unused-vars */
 	api.use((error, req, res, next) => {


### PR DESCRIPTION
Slack (sometimes) sends back data as `urlencoded`.

The parse as `text` is because for the signing secret validation, the body must be in it's `raw` form (unparsed). I tried simply adding an `urlencoded` parser here and then possible unparsing the data, but slack uses different escapes for some characters, so decided to go with this.

I chose `text` over `raw` mostly because of the logging. `raw` returns a `Buffer` which really messes with our logs right now, and for what we need there is no difference between `text` and `raw`