### PR TITLE
Deal with dots in hosted zone name

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.exclude": {
+    "**/bin/": false,
+  }
+}

--- a/bin/template/cloudFormationHostedZoneTemplate.json
+++ b/bin/template/cloudFormationHostedZoneTemplate.json
@@ -33,8 +33,18 @@
             "Fn::Join": [
                 "-",
                 [
-                    { "Ref": "hostedZoneName" },
-                    "CertResolver"
+                  {
+                    "Fn::Join": [
+                      "-",
+                      {
+                        "Fn::Split" : [
+                          ".",
+                          { "Ref": "hostedZoneName" }
+                        ]
+                      }
+                    ]
+                  },
+                  "CertResolver"
                 ]
             ]
         },


### PR DESCRIPTION
* Deal with dots in the hostedZoneName so that it leads to a valid lambda function name.
* Do not hide the bin folder in VSCode. (Happy to put that in a separate pull request if needed.)