### PR TITLE
Throw to client when invalid parameters got specified

### DIFF
--- a/lib/CloudFormationDeployer.js
+++ b/lib/CloudFormationDeployer.js
@@ -228,7 +228,7 @@ module.exports = function CloudFormationDeployer(cloudFormationClient, bucketMan
 
 			return stackData;
 		} catch (error) {
-			if (error.code === 'ValidationError') {
+			if (error.code === 'ValidationError' || error.code === 'InvalidParameterType') {
 				throw error;
 			}
 			let changeSetResponse = await this.cloudFormationClient.describeChangeSet(executeParameters).promise();


### PR DESCRIPTION
When invalid parameters got specified, it ended up in a generic error message, misleading what's wrong.

This one will show something like: `Expected params.Parameters[0].ParameterValue to be a string`.