### PR TITLE
Increase the payload limit

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -94,7 +94,7 @@ function Server(contentDirectory, lambdaApi, logger) {
 	this.App.use('/api/', api);
 
 	api.use(bodyParser.text({ type: 'application/x-www-form-urlencoded' }));
-	api.use(bodyParser.json({ type: '*/*' }));
+	api.use(bodyParser.json({ type: '*/*', limit: '6mb' }));
 	/* eslint-disable-next-line no-unused-vars */
 	api.use((error, req, res, next) => {
 		res.status(400).send({ error: 'Invalid JSON' });


### PR DESCRIPTION
So... i ran into this problem where i was trying to submit a payload but it threw an `Invalid JSON` error, even though it was valid.

After some digging through all possible dependencies in my project i figured it came from here.

After some more digging it became apparent that it was caused by [express' body-parser middleware](https://github.com/expressjs/body-parser), because my payload was larger than the default allowed by body-parser.

I've increased the payload limit to 6mb to be in sync with [lambda's payload limit](https://docs.aws.amazon.com/lambda/latest/dg/limits.html)