### PR TITLE
Add some default content-types for body parser server.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,3 +1,4 @@
+const stringify = require('json-stringify-safe');
 const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const express = require('express');
@@ -34,7 +35,7 @@ function Server(contentDirectory, lambdaApi, logger) {
 	this.App.use((req, res, next) => {
 		this.logger('********************************************************************************');
 		fixHeaders(req.headers);
-		this.logger(`Request Headers: ${JSON.stringify(req.headers, null, 2)}`);
+		this.logger(`Request Headers: ${stringify(req.headers, null, 2)}`);
 		this.logger('----------------------------------');
 		next();
 	});
@@ -46,7 +47,7 @@ function Server(contentDirectory, lambdaApi, logger) {
 	events.use(bodyParser.json({ type: '*/*' }));
 	this.App.use('/triggers/', events);
 	events.post('/event', async (req, res) => {
-		this.logger(`New Event: ${JSON.stringify(req.body, null, 2)}`);
+		this.logger(`New Event: ${stringify(req.body, null, 2)}`);
 		try {
 			let context = {
 				functionName: 'lambdaApi',
@@ -62,13 +63,13 @@ function Server(contentDirectory, lambdaApi, logger) {
 			let result = await eventHandler(req.body, context);
 			return res.status(200).json(result || {});
 		} catch (exception) {
-			this.logger(JSON.stringify({ title: 'Exception thrown by invocation of the runtime event function, check the implementation.', error: exception }, replaceErrors, 2));
+			this.logger(stringify({ title: 'Exception thrown by invocation of the runtime event function, check the implementation.', error: exception }, replaceErrors, 2));
 			let body = exception instanceof Error ? exception.toString() : exception;
 			return res.status(500).json({ title: 'Internal Error, check logs', error: body });
 		}
 	});
 	events.post('/schedule', async (req, res) => {
-		this.logger(`New Schedule: ${JSON.stringify(req.body)}`);
+		this.logger(`New Schedule: ${stringify(req.body)}`);
 		try {
 			let context = {
 				functionName: 'lambdaApi',
@@ -84,7 +85,7 @@ function Server(contentDirectory, lambdaApi, logger) {
 			let result = await scheduleHandler(req.body, context);
 			return res.status(200).json(result || {});
 		} catch (exception) {
-			this.logger(JSON.stringify({ title: 'Exception thrown by invocation of the runtime event function, check the implementation.', error: exception }, replaceErrors, 2));
+			this.logger(stringify({ title: 'Exception thrown by invocation of the runtime event function, check the implementation.', error: exception }, replaceErrors, 2));
 			let body = exception instanceof Error ? exception.toString() : exception;
 			return res.status(500).json({ title: 'Internal Error, check logs', error: body });
 		}
@@ -93,11 +94,13 @@ function Server(contentDirectory, lambdaApi, logger) {
 	let api = express.Router();
 	this.App.use('/api/', api);
 
-	api.use(bodyParser.text({ type: 'application/x-www-form-urlencoded' }));
+	api.use(bodyParser.text({ type: ['application/x-www-form-urlencoded', 'text/css', 'text/csv', 'text/html', 'text/plain', 'text/html'] }));
+	api.use(bodyParser.raw({ type: ['application/octet-stream', 'application/binary', 'image/*', 'audio/*', 'video/*', 'application/pdf', 'application/x-tar', 'application/zip'], limit: '6mb' }));
 	api.use(bodyParser.json({ type: '*/*', limit: '6mb' }));
 	/* eslint-disable-next-line no-unused-vars */
 	api.use((error, req, res, next) => {
-		res.status(400).send({ error: 'Invalid JSON' });
+		this.logger(stringify({ title: 'Failed to parse the body', error }));
+		res.status(400).send({ title: 'Invalid body parsing, it can be due to the default parsing types that are set up in AWS Architect Server configuration' });
 	});
 
 	/* eslint-disable-next-line no-unused-vars */
@@ -190,12 +193,12 @@ function Server(contentDirectory, lambdaApi, logger) {
 				}
 
 				this.logger(`StatusCode: ${response.statusCode}`);
-				this.logger(`Headers: ${JSON.stringify(response.headers, null, 2)}`);
+				this.logger(`Headers: ${stringify(response.headers, null, 2)}`);
 
 				try {
 					response.body = response.body && response.body.replace(/"https?:\/\/(localhost:\d{2,5})\/([^"]*)"/g, '"http://$1/api/$2"');
 					let json = JSON.parse(response.body);
-					this.logger(`Body: ${JSON.stringify(json, null, 2)}`);
+					this.logger(`Body: ${stringify(json, null, 2)}`);
 					return res.status(response.statusCode).json(json);
 				} catch (exception) {
 					this.logger('Body: Not-JSON');
@@ -215,7 +218,7 @@ function Server(contentDirectory, lambdaApi, logger) {
 
 	/* eslint-disable-next-line no-unused-vars */
 	api.use((error, req, res, next) => {
-		console.error(`Catch-all Error: ${error.stack || error} - ${JSON.stringify(error, null, 2)}`);
+		console.error(`Catch-all Error: ${error.stack || error} - ${stringify(error, null, 2)}`);
 		res.status(500).json({
 			statusCode: 500,
 			title: 'Catch-all Error',

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "express": "^4.13.4",
     "fs-extra": "^6.0.1",
     "header-case-normalizer": "^1.0.3",
+    "json-stringify-safe": "^5.0.1",
     "morgan": "^1.7.0",
     "tmp": "^0.0.33",
     "uuid": "^2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,6 +987,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json-stringify-safe@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"


### PR DESCRIPTION
FYI @runebaas 
I pulled a list of content types from [Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types) to parse by default. We can add in overrides later if for some reason it needs to, but I'm not expecting the need.