### PR TITLE
Enable deployment on Windows systems.

### DIFF
--- a/lib/BucketManager.js
+++ b/lib/BucketManager.js
@@ -43,7 +43,7 @@ class BucketManager {
 					let cacheControl = matchingCacheMap && matchingCacheMap.value || cacheControlRegexMap[relativePath] || cacheControlRegexMap.default || 600;
 					return this.S3Manager.putObject({
 						Bucket: this.Bucket,
-						Key: path.join(version, relativePath),
+						Key: path.join(version, relativePath).replace(/\\/g, '/'),
 						Body: fs.createReadStream(file),
 						ContentType: contentTypeMapping[path.extname(file)] || contentTypeMapping.default || 'text/plain',
 						CacheControl: typeof maxAge === 'number' ? `public, max-age=${cacheControl}` : cacheControl

--- a/lib/BucketManager.js
+++ b/lib/BucketManager.js
@@ -37,13 +37,14 @@ class BucketManager {
 			return sortedList.concat(indexList).reduce((listPromise, file) => {
 				return listPromise.then(() => {
 					let relativePath = path.relative(path.resolve(contentPath), path.resolve(file));
+					let relativePathUnixFormat = this.unixify(relativePath);
 					let matchingCacheMap = Array.isArray(cacheControlRegexMap) && cacheControlRegexMap.find(m => {
-						return !m.explicit && !m.regex || m.explicit === relativePath || m.regex && m.regex.exec && m.regex.exec(file);
+						return !m.explicit && !m.regex || m.explicit === relativePathUnixFormat || m.regex && m.regex.exec && m.regex.exec(file);
 					});
-					let cacheControl = matchingCacheMap && matchingCacheMap.value || cacheControlRegexMap[relativePath] || cacheControlRegexMap.default || 600;
+					let cacheControl = matchingCacheMap && matchingCacheMap.value || cacheControlRegexMap[relativePathUnixFormat] || cacheControlRegexMap.default || 600;
 					return this.S3Manager.putObject({
 						Bucket: this.Bucket,
-						Key: path.join(version, relativePath).replace(/\\/g, '/'),
+						Key: this.unixify(path.join(version, relativePath)),
 						Body: fs.createReadStream(file),
 						ContentType: contentTypeMapping[path.extname(file)] || contentTypeMapping.default || 'text/plain',
 						CacheControl: typeof maxAge === 'number' ? `public, max-age=${cacheControl}` : cacheControl
@@ -61,7 +62,7 @@ class BucketManager {
 	DeployLambdaPromise(bucket, localPath, remotePath) {
 		return this.S3Manager.upload({
 			Bucket: bucket || this.Bucket,
-			Key: remotePath,
+			Key: this.unixify(remotePath),
 			Body: fs.createReadStream(localPath),
 			ContentType: contentTypeMappingConst[path.extname(remotePath)] || contentTypeMappingConst.default || 'text/plain',
 			CacheControl: 'public, max-age=10'
@@ -88,13 +89,18 @@ class BucketManager {
 				return listPromise.then(() => {
 					return this.S3Manager.copyObject({
 						Bucket: this.Bucket,
-						Key: path.join(target, path.relative(source, key)),
-						CopySource: `${this.Bucket}/${key}`
+						Key: this.unixify(path.join(target, path.relative(source, key))),
+						CopySource: `${this.Bucket}/${this.unixify(key)}`
 					}).promise()
 					.catch(failure => Promise.reject({ Source: key, Error: failure.stack || failure.toString(), Detail: failure }));
 				}).then(() => Promise.resolve({ Title: 'Promote to stage success', Bucket: this.Bucket, Source: source, Target: target }));
 			}, Promise.resolve([]));
 		});
+	}
+
+	// ensures a path will be in unix format (that is, forward slash), also on Windows systems.
+	unixify(fullPath) {
+		return fullPath.replace(/\\/g, '/');
 	}
 }
 


### PR DESCRIPTION
Sigh... the deployment of an SPA to S3 ended up creating a bunch of files like `v1\index.html` and `v1\index.js` instead of `v1/index.html`.

Not a problem on the build server, but useful locally when running on a windows machine.