### PR TITLE
The template used a variable serviceName. Add this as a parameter.

### DIFF
--- a/bin/template/cloudFormationWebsiteTemplate.json
+++ b/bin/template/cloudFormationWebsiteTemplate.json
@@ -1,6 +1,10 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Parameters": {
+    "serviceName": {
+      "Type": "String",
+      "Description": "The name of the service / website. Must not contain special characters except hyphens."
+    },
     "dnsName": {
       "Type": "String",
       "Description": "The DNS name to map to S3 bucket."

--- a/bin/template/make.js
+++ b/bin/template/make.js
@@ -116,6 +116,7 @@ commander
 		await awsArchitect.ValidateTemplate(stackTemplate, stackConfiguration);
 		if (isMasterBranch) {
 			let parameters = {
+				serviceName: 'example-service', // must result in a valid Lambda name; for example cannot contain "."
 				dnsName: packageMetadata.name.toLowerCase(),
 				hostedName: 'toplevel.domain.io',
 				useRoot: 'true'


### PR DESCRIPTION
There are probably alternative ways of trying to construct a unique lambda function name, but I thought it's the most straight forward and explicit to ask for a given name.