### PR TITLE
Revert upgrade to v8.10 for Lambda Callouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ This is the changelog for [AWS Architect](readme.md).
 ## 6.2 ##
 * Allow setting upload zip file directly to support creating lambda layers
 * Add `publishZipArchive` to publish layers and other zip files directly to S3, using the package name and version automatically.
-* Upgrade default nodejs version to 8.10. for Lambda Callouts (mostly around creating and managing ACM certificates).
 
 ## 6.1 ##
 * Deploy CF templates to S3 deployment bucket before deploying to CF to increase allow size of templates to 450KB.

--- a/bin/acm_with_dns_validation.json
+++ b/bin/acm_with_dns_validation.json
@@ -75,7 +75,7 @@
         }
     },
     "Handler": "index.handler",
-    "Runtime": "nodejs8.10",
+    "Runtime": "nodejs6.10",
     "Timeout": "30",
     "Role": { "Fn::GetAtt": [ "CreateAndReturnAcmCertificateArnRole", "Arn" ] }
     }

--- a/bin/template/cloudFormationHostedZoneTemplate.json
+++ b/bin/template/cloudFormationHostedZoneTemplate.json
@@ -103,7 +103,7 @@
           }
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs6.10",
         "Timeout": "30",
         "Role": { "Fn::GetAtt": [ "CreateAndReturnAcmCertificateArnRole", "Arn" ] }
       }

--- a/bin/template/cloudFormationServerlessTemplate.json
+++ b/bin/template/cloudFormationServerlessTemplate.json
@@ -479,7 +479,7 @@
           }
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs6.10",
         "Timeout": "30",
         "Role": { "Fn::GetAtt": [ "GetExistingAcmCertificateArnRole", "Arn" ] }
       }
@@ -610,7 +610,7 @@
           }
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs6.10",
         "Timeout": "30",
         "Role": { "Fn::GetAtt": [ "GetRoute53ConfigurationInformationRole", "Arn" ] }
       }

--- a/bin/template/cloudFormationWebsiteTemplate.json
+++ b/bin/template/cloudFormationWebsiteTemplate.json
@@ -179,7 +179,7 @@
           }
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs6.10",
         "Timeout": "30",
         "Role": { "Fn::GetAtt": [ "GetExistingAcmCertificateArnRole", "Arn" ] }
       }


### PR DESCRIPTION
The Lambda Callouts just hang forever when running them on v8.10. They are called, but the CF template never continues past this resource, and gives up after 1h. The CloudWatch Logs clearly indicate a successful call. So it's a bit mysterious what the reason is.

Reverting my change from https://github.com/wparad/aws-architect.js/pull/36