### PR TITLE
Upgrade to Node8

### DIFF
--- a/bin/acm_with_dns_validation.json
+++ b/bin/acm_with_dns_validation.json
@@ -30,7 +30,7 @@
             "exports.handler = function(event, context) {",
             "  let domainName = event.ResourceProperties.DomainName;",
             "  if (event.RequestType === 'Delete') {",
-            "    return acmClient.listCertificates({}).promise()",
+            "    acmClient.listCertificates({}).promise()",
             "      .then(certs => {",
             "        let foundCert = certs.CertificateSummaryList.find(cert => cert.DomainName === domainName);",
             "        if (foundCert) {",
@@ -47,10 +47,10 @@
             "  }",
             "  ",
             "  if (event.RequestType !== 'Create') {",
-            "    return cloudFormationResponseHandler.send(event, context, cloudFormationResponseHandler.SUCCESS);",
+            "    cloudFormationResponseHandler.send(event, context, cloudFormationResponseHandler.SUCCESS);",
             "  }",
             "  ",
-            "  return acmClient.requestCertificate({ DomainName: domainName, SubjectAlternativeNames: [`*.${domainName}`], ValidationMethod: 'DNS' }).promise()",
+            "  acmClient.requestCertificate({ DomainName: domainName, SubjectAlternativeNames: [`*.${domainName}`], ValidationMethod: 'DNS' }).promise()",
             "    .then(data => {",
             "      return new Promise(resolve => setTimeout(resolve, 10000))",
             "        .then(() => {",
@@ -75,7 +75,7 @@
         }
     },
     "Handler": "index.handler",
-    "Runtime": "nodejs6.10",
+    "Runtime": "nodejs8.10",
     "Timeout": "30",
     "Role": { "Fn::GetAtt": [ "CreateAndReturnAcmCertificateArnRole", "Arn" ] }
     }

--- a/bin/template/cloudFormationHostedZoneTemplate.json
+++ b/bin/template/cloudFormationHostedZoneTemplate.json
@@ -58,7 +58,7 @@
               "exports.handler = function(event, context) {",
               "  let domainName = event.ResourceProperties.DomainName;",
               "  if (event.RequestType === 'Delete') {",
-              "    return acmClient.listCertificates({}).promise()",
+              "    acmClient.listCertificates({}).promise()",
               "      .then(certs => {",
               "        let foundCert = certs.CertificateSummaryList.find(cert => cert.DomainName === domainName);",
               "        if (foundCert) {",
@@ -76,10 +76,10 @@
               "  }",
               "  ",
               "  if (event.RequestType !== 'Create') {",
-              "    return cloudFormationResponseHandler.send(event, context, cloudFormationResponseHandler.SUCCESS);",
+              "    cloudFormationResponseHandler.send(event, context, cloudFormationResponseHandler.SUCCESS);",
               "  }",
               "  ",
-              "  return acmClient.requestCertificate({ DomainName: domainName, SubjectAlternativeNames: [`*.${domainName}`], ValidationMethod: 'DNS' }).promise()",
+              "  acmClient.requestCertificate({ DomainName: domainName, SubjectAlternativeNames: [`*.${domainName}`], ValidationMethod: 'DNS' }).promise()",
               "    .then(data => {",
               "      return new Promise(resolve => setTimeout(resolve, 20000))",
               "        .then(() => {",
@@ -103,7 +103,7 @@
           }
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs8.10",
         "Timeout": "30",
         "Role": { "Fn::GetAtt": [ "CreateAndReturnAcmCertificateArnRole", "Arn" ] }
       }

--- a/bin/template/cloudFormationServerlessTemplate.json
+++ b/bin/template/cloudFormationServerlessTemplate.json
@@ -460,7 +460,7 @@
               "  let domainName = event.ResourceProperties.DomainName;",
               "  let region = event.ResourceProperties.Region;",
               "  let acmClient = new aws.ACM({ region: region });",
-              "  return acmClient.listCertificates({}).promise()",
+              "  acmClient.listCertificates({}).promise()",
               "    .then(certs => {",
               "      let foundCert = certs.CertificateSummaryList.find(cert => cert.DomainName === domainName);",
               "      return foundCert ? foundCert.CertificateArn: null;",
@@ -479,7 +479,7 @@
           }
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs8.10",
         "Timeout": "30",
         "Role": { "Fn::GetAtt": [ "GetExistingAcmCertificateArnRole", "Arn" ] }
       }
@@ -595,11 +595,11 @@
               "const aws = require('aws-sdk');",
               "exports.handler = function(event, context) {",
               "  if (event.RequestType === 'Delete') {",
-              "    return cloudFormationResponseHandler.send(event, context, cloudFormationResponseHandler.SUCCESS);",
+              "    cloudFormationResponseHandler.send(event, context, cloudFormationResponseHandler.SUCCESS);",
               "  }",
               "  let domainName = event.ResourceProperties.DomainName;",
               "  let apiGatewayClient = new aws.APIGateway();",
-              "  return apiGatewayClient.getDomainName({ domainName: domainName }).promise()",
+              "  apiGatewayClient.getDomainName({ domainName: domainName }).promise()",
               "  .then(response => {",
               "    return cloudFormationResponseHandler.send(event, context, cloudFormationResponseHandler.SUCCESS, { 'DistributionDomainName': response.regionalDomainName || response.distributionDomainName, 'HostedZone': response.regionalHostedZoneId || response.distributionHostedZoneId });",
               "  }, failure => {",
@@ -610,7 +610,7 @@
           }
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs8.10",
         "Timeout": "30",
         "Role": { "Fn::GetAtt": [ "GetRoute53ConfigurationInformationRole", "Arn" ] }
       }

--- a/bin/template/cloudFormationWebsiteTemplate.json
+++ b/bin/template/cloudFormationWebsiteTemplate.json
@@ -160,7 +160,7 @@
             "let acmClient = new aws.ACM({ region: 'us-east-1' });",
             "exports.handler = function(event, context) {",
             "  let domainName = event.ResourceProperties.DomainName;",
-            "  return acmClient.listCertificates({}).promise()",
+            "  acmClient.listCertificates({}).promise()",
             "    .then(certs => {",
             "      let foundCert = certs.CertificateSummaryList.find(cert => cert.DomainName === domainName);",
             "      return foundCert ? foundCert.CertificateArn : null;",
@@ -179,7 +179,7 @@
           }
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs8.10",
         "Timeout": "30",
         "Role": { "Fn::GetAtt": [ "GetExistingAcmCertificateArnRole", "Arn" ] }
       }


### PR DESCRIPTION
* Node 6 runtimes cannot be created anymore
* Just removed all top-level returns of the promise
* Longer term, we might want to rewrite those functions as async-await and simplify/clarify better. It's a weird mix of not returning a promise and the black-box of cfn-response creates a valid response on the context.