### PR TITLE
Increase local HTTP server timeout to match max Lambda timeout

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -266,6 +266,9 @@ async function getNextPort(initialPort) {
 
 Server.prototype.Run = async function(port) {
 	let httpServer = http.createServer(this.App);
+	// set local HTTP server timeout to max Lambda timeout of 15 minutes; default is 2 minutes
+	// see https://nodejs.org/dist/latest-v6.x/docs/api/http.html#http_server_settimeout_msecs_callback
+	httpServer.setTimeout(15 * 60 * 1000);
 	http.createServer(this.App);
 
 	let availablePort = await getNextPort(port);


### PR DESCRIPTION
Before:
If a request took more than 2 minutes (locally), the request still continued in the background, completing the async operations, but the caller already got a timeout back.

Now:
It's waiting for the background process to complete for local processing. I matched it up to 15 minutes to match the max Lambda timeout.