### PR TITLE
Report MultipleValidationErrors from CF deployment

### DIFF
--- a/lib/CloudFormationDeployer.js
+++ b/lib/CloudFormationDeployer.js
@@ -228,7 +228,7 @@ module.exports = function CloudFormationDeployer(cloudFormationClient, bucketMan
 
 			return stackData;
 		} catch (error) {
-			if (error.code === 'ValidationError' || error.code === 'InvalidParameterType') {
+			if (error.code === 'ValidationError' || error.code === 'MultipleValidationErrors' || error.code === 'InvalidParameterType') {
 				throw error;
 			}
 			let changeSetResponse = await this.cloudFormationClient.describeChangeSet(executeParameters).promise();


### PR DESCRIPTION
I had multiple errors in my CF and aws-architect was outputting this to the console:
`{ ValidationError: Stack [stackName] does not exist`....`

Which somehow did not make sense. After debugging, I found that aws-architect rethrows only `ValidationError` but not `MultipleValidationErrors`. Therefore, I am proposing to add it there.