### PR TITLE
Enhancing request context during local execution

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -141,7 +141,16 @@ function Server(contentDirectory, lambdaApi, logger) {
 					body: req.body,
 					stageVariables: { lambdaVersion: 'local' },
 					requestContext: {
-						requestId: 'Invoked-from-AwsArchitect'
+						requestId: 'Invoked-from-AwsArchitect',
+						resourceId: 'local',
+						stage: 'local',
+						identity: {
+							cognitoIdentityId: 'local',
+							cognitoIdentityPoolId: null,
+							apiKey: null,
+							sourceIp: req.headers['x-forwarded-for'] || req.connection.remoteAddress,
+							userAgent: req.get('User-Agent')
+						}
 					}
 				};
 				let context = {
@@ -158,9 +167,7 @@ function Server(contentDirectory, lambdaApi, logger) {
 					try {
 						let authorizerFunc = lambdaApi.Authorizer.AuthorizerFunc || lambdaApi.authorizer || lambdaApi.Authorizer || (() => ({ principalId: '<no-authorizer-func-specified>' }));
 						let result = await authorizerFunc(event);
-						event.requestContext = {
-							authorizer: result.context || {}
-						};
+						event.requestContext.authorizer = result.context || {};
 						event.requestContext.authorizer.principalId = result.principalId;
 					} catch (authorizerError) {
 						console.error(authorizerError.stack || authorizerError);


### PR DESCRIPTION
Matching more of the documentation: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format